### PR TITLE
Feature/chaos monkey log confirm

### DIFF
--- a/src/main/java/com/networknt/controller/ControllerChaosMonkey.java
+++ b/src/main/java/com/networknt/controller/ControllerChaosMonkey.java
@@ -75,41 +75,73 @@ public class ControllerChaosMonkey {
         return config;
     }
 
+    /**
+     * Initiate a specified chaos monkey assault and get the logs of the service after.
+     * We do not want to try to grab logs of killapp or exception, because this means the service is shutdown.
+     *
+     * @param assaultType - chaos monkey assault handler.
+     * @param address - address of service we are going to assault.
+     * @param port - port of service we are going to assault.
+     * @param protocol - protocol of service we are going to assault.
+     * @param endpoint - endpoint of service we are going to hit
+     * @param reqCount - the amount of times we are going to request until the assault is complete.
+     * @return - return confirmation string that the assault happened or the log entries.
+     */
     public static String initChaosMonkeyAssault(String assaultType, String address, int port, String protocol, String endpoint, int reqCount) {
         boolean testCompleted;
         String assaultHandlerName;
+        boolean getLog;
         String startTime = String.valueOf(System.currentTimeMillis());
         switch (assaultType) {
             case EXCEPTION_ASSAULT:
                 testCompleted = initExceptionAssault(protocol, address, String.valueOf(port), endpoint, reqCount);
                 assaultHandlerName = "Exception Assault";
+                getLog = false;
                 break;
             case KILL_APP_ASSAULT:
                 testCompleted = initKillAppAssault(protocol, address, String.valueOf(port), endpoint, reqCount);
                 assaultHandlerName = "Kill App Assault";
+                getLog = false;
                 break;
             case LATENCY_ASSAULT:
                 testCompleted = initLatencyAssault(protocol, address, String.valueOf(port), endpoint, reqCount);
                 assaultHandlerName = "Latency Assault";
+                getLog = true;
                 break;
             case MEMORY_ASSAULT:
                 testCompleted = initMemoryAssault(protocol, address, String.valueOf(port), endpoint, reqCount);
                 assaultHandlerName = "Memory Assault";
+                getLog = true;
                 break;
             default:
                 assaultHandlerName = "Unknown Assault Type: " + assaultType;
                 testCompleted = false;
+                getLog = false;
                 break;
         }
         String endTime = String.valueOf(System.currentTimeMillis());
 
         if(testCompleted) {
-            return confirmLog(address, port, protocol, startTime, endTime);
+            if(getLog) {
+                return confirmLog(address, port, protocol, startTime, endTime);
+            } else {
+                return "Chaos test success.";
+            }
         } else {
             return "Test was not completed for triggered assault: " + assaultHandlerName + "\n" + "Is the handler name correct? Is the specified handler enabled with bypass disabled?";
         }
     }
 
+    /**
+     * Retrieve the logs after chaos monkey assault to confirm the test happened.
+     *
+     * @param address - address of service
+     * @param port - port of service
+     * @param protocol - protocol of service.
+     * @param startTime - startTime of log
+     * @param endTime - endTime of log
+     * @return - return JSON string of log entries from service.
+     */
     private static String confirmLog(String address, int port, String protocol, String startTime, String endTime) {
         long currentTime = System.currentTimeMillis();
         long timeout = currentTime + TIMEOUT;

--- a/src/main/java/com/networknt/controller/ControllerChaosMonkey.java
+++ b/src/main/java/com/networknt/controller/ControllerChaosMonkey.java
@@ -8,7 +8,6 @@ import com.networknt.chaos.KillappAssaultConfig;
 import com.networknt.chaos.LatencyAssaultConfig;
 import com.networknt.chaos.MemoryAssaultConfig;
 import com.networknt.config.JsonMapper;
-import com.networknt.controller.model.LoggerInfo;
 import com.networknt.status.HttpStatus;
 import io.undertow.util.Methods;
 import org.slf4j.Logger;
@@ -24,7 +23,7 @@ public class ControllerChaosMonkey {
     private static final String LATENCY_ASSAULT = "com.networknt.chaos.LatencyAssaultHandler";
     private static final String MEMORY_ASSAULT = "com.networknt.chaos.MemoryAssaultHandler";
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final long TIMEOUT = 3000;
+    private static final long TIMEOUT = 30000;
 
     public static String getChaosMonkeyInfo(String protocol, String address, int port) {
         ServiceRequest serviceRequest = new ServiceRequest.Builder(protocol, address, String.valueOf(port), Methods.GET)
@@ -90,43 +89,33 @@ public class ControllerChaosMonkey {
     public static String initChaosMonkeyAssault(String assaultType, String address, int port, String protocol, String endpoint, int reqCount) {
         boolean testCompleted;
         String assaultHandlerName;
-        boolean getLog;
         String startTime = String.valueOf(System.currentTimeMillis());
         switch (assaultType) {
             case EXCEPTION_ASSAULT:
                 testCompleted = initExceptionAssault(protocol, address, String.valueOf(port), endpoint, reqCount);
                 assaultHandlerName = "Exception Assault";
-                getLog = false;
                 break;
             case KILL_APP_ASSAULT:
                 testCompleted = initKillAppAssault(protocol, address, String.valueOf(port), endpoint, reqCount);
                 assaultHandlerName = "Kill App Assault";
-                getLog = false;
                 break;
             case LATENCY_ASSAULT:
                 testCompleted = initLatencyAssault(protocol, address, String.valueOf(port), endpoint, reqCount);
                 assaultHandlerName = "Latency Assault";
-                getLog = true;
                 break;
             case MEMORY_ASSAULT:
                 testCompleted = initMemoryAssault(protocol, address, String.valueOf(port), endpoint, reqCount);
                 assaultHandlerName = "Memory Assault";
-                getLog = true;
                 break;
             default:
                 assaultHandlerName = "Unknown Assault Type: " + assaultType;
                 testCompleted = false;
-                getLog = false;
                 break;
         }
         String endTime = String.valueOf(System.currentTimeMillis());
 
         if(testCompleted) {
-            if(getLog) {
-                return confirmLog(address, port, protocol, startTime, endTime);
-            } else {
-                return "Chaos test success.";
-            }
+            return confirmLog(address, port, protocol, startTime, endTime);
         } else {
             return "Test was not completed for triggered assault: " + assaultHandlerName + "\n" + "Is the handler name correct? Is the specified handler enabled with bypass disabled?";
         }

--- a/src/main/java/com/networknt/controller/ControllerClient.java
+++ b/src/main/java/com/networknt/controller/ControllerClient.java
@@ -42,20 +42,14 @@ public class ControllerClient {
     }
 
     public static String getLogContents(String protocol, String address, int port, LoggerInfo loggerInfo, String startTime, String endTime) {
-        ServiceRequest.Builder serviceRequestBuilder = new ServiceRequest.Builder(protocol, address, String.valueOf(port), Methods.GET)
+        ServiceRequest serviceRequest = new ServiceRequest.Builder(protocol, address, String.valueOf(port), Methods.GET)
                 .addQueryParam("startTime", startTime)
                 .addQueryParam("endTime", endTime)
-                .buildFullPath(LOGGER_CONTENT_ENDPOINT);
+                .addQueryParam("loggerName", loggerInfo.getName())
+                .addQueryParam("loggerLevel", loggerInfo.getLevel().toString())
+                .buildFullPath(LOGGER_CONTENT_ENDPOINT)
+                .build();
 
-        if(loggerInfo.getName() != null) {
-            serviceRequestBuilder.addQueryParam("loggerName", loggerInfo.getName());
-        }
-
-        if(loggerInfo.getLevel() != null) {
-            serviceRequestBuilder.addQueryParam("loggerLevel", loggerInfo.getLevel().toString());
-        }
-
-        ServiceRequest serviceRequest = serviceRequestBuilder.build();
         serviceRequest.sendRequest();
         return serviceRequest.getResponseBody();
     }

--- a/src/main/java/com/networknt/controller/ControllerClient.java
+++ b/src/main/java/com/networknt/controller/ControllerClient.java
@@ -1,7 +1,10 @@
 package com.networknt.controller;
 
+import com.networknt.controller.model.LoggerInfo;
 import io.undertow.util.Methods;
 import java.util.List;
+
+import static com.networknt.controller.ControllerConstants.*;
 
 public class ControllerClient {
 
@@ -15,7 +18,7 @@ public class ControllerClient {
 
     public static String getServerInfo(String protocol, String address, int port) {
         ServiceRequest serviceRequest = new ServiceRequest.Builder(protocol, address, String.valueOf(port), Methods.GET)
-                .buildFullPath("/server/info")
+                .buildFullPath(SERVER_INFO_ENDPOINT)
                 .build();
         serviceRequest.sendRequest();
         return serviceRequest.getResponseBody();
@@ -23,17 +26,36 @@ public class ControllerClient {
 
     public static String getLoggerConfig(String protocol, String address, String port) {
         ServiceRequest serviceRequest = new ServiceRequest.Builder(protocol, address, String.valueOf(port), Methods.GET)
-                .buildFullPath("/logger")
+                .buildFullPath(LOGGER_ENDPOINT)
                 .build();
         serviceRequest.sendRequest();
         return serviceRequest.getResponseBody();
     }
 
-    public static String updateLoggerConfig(String protocol, String address, int port, List loggers) {
+    public static String updateLoggerConfig(String protocol, String address, int port, List<?> loggers) {
         ServiceRequest serviceRequest = new ServiceRequest.Builder(protocol, address, String.valueOf(port), Methods.POST)
                 .withRequestBody(loggers)
-                .buildFullPath("/logger")
+                .buildFullPath(LOGGER_ENDPOINT)
                 .build();
+        serviceRequest.sendRequest();
+        return serviceRequest.getResponseBody();
+    }
+
+    public static String getLogContents(String protocol, String address, int port, LoggerInfo loggerInfo, String startTime, String endTime) {
+        ServiceRequest.Builder serviceRequestBuilder = new ServiceRequest.Builder(protocol, address, String.valueOf(port), Methods.GET)
+                .addQueryParam("startTime", startTime)
+                .addQueryParam("endTime", endTime)
+                .buildFullPath(LOGGER_CONTENT_ENDPOINT);
+
+        if(loggerInfo.getName() != null) {
+            serviceRequestBuilder.addQueryParam("loggerName", loggerInfo.getName());
+        }
+
+        if(loggerInfo.getLevel() != null) {
+            serviceRequestBuilder.addQueryParam("loggerLevel", loggerInfo.getLevel().toString());
+        }
+
+        ServiceRequest serviceRequest = serviceRequestBuilder.build();
         serviceRequest.sendRequest();
         return serviceRequest.getResponseBody();
     }

--- a/src/main/java/com/networknt/controller/ControllerConstants.java
+++ b/src/main/java/com/networknt/controller/ControllerConstants.java
@@ -1,6 +1,6 @@
 package com.networknt.controller;
 
-public class ControllerConstants {
+public final class ControllerConstants {
     public static int NONCE = 1;
     public static String HOST = "lightapi.net";
     public static String CHECK = "check";
@@ -10,6 +10,8 @@ public class ControllerConstants {
     public static final String PORT = "port";
     public static final String PROTOCOL = "protocol";
     public static final String ADDRESS = "address";
+    public static final String SERVICE_ID = "serviceId";
+    public static final String TAG = "tag";
 
     /* Client Controller Path Strings */
     public static final String SERVER_INFO_ENDPOINT = "/server/info";

--- a/src/main/java/com/networknt/controller/ControllerConstants.java
+++ b/src/main/java/com/networknt/controller/ControllerConstants.java
@@ -5,4 +5,17 @@ public class ControllerConstants {
     public static String HOST = "lightapi.net";
     public static String CHECK = "check";
     public static int CHECK_FREQUENCY = 10; // check the health every 10 seconds by default.
+
+    /* Common Query Parameter Names */
+    public static final String PORT = "port";
+    public static final String PROTOCOL = "protocol";
+    public static final String ADDRESS = "address";
+
+    /* Client Controller Path Strings */
+    public static final String SERVER_INFO_ENDPOINT = "/server/info";
+    public static final String LOGGER_ENDPOINT = "/logger";
+    public static final String LOGGER_CONTENT_ENDPOINT = "/logger/contents";
+    public static final String CHAOS_MONKEY_ASSAULT_ENDPOINT = "/chaosmonkey/{assaultType}";
+    public static final String CHAOS_MONKEY_ENDPOINT = "/chaosmonkey";
+
 }

--- a/src/main/java/com/networknt/controller/ServiceRequest.java
+++ b/src/main/java/com/networknt/controller/ServiceRequest.java
@@ -63,6 +63,8 @@ public class ServiceRequest {
         private final Map<String, String> pathParams = new HashMap<>();
         private final Map<String, String> queryParams = new HashMap<>();
 
+        private final static String PATH_PARAM_PATTERN = "[{]+[a-zA-Z-0-9]+[}]";
+
         public Builder(String protocol, String address, String port, HttpString method) {
             this.protocol = protocol;
             this.method = method;
@@ -71,17 +73,41 @@ public class ServiceRequest {
             this.connection = establishBaseConnection(protocol, address, port);
         }
 
-
+        /**
+         * Add a path param to our request.
+         *
+         * @param k - the key name of the param.
+         * @param v - the value of the param.
+         * @return - this.
+         */
         public Builder addPathParam(String k, Object v) {
-            this.pathParams.put(k, v.toString());
+            if(v != null) {
+                this.pathParams.put(k, v.toString());
+            }
             return this;
         }
 
+        /**
+         * Add a query param to our request.
+         *
+         * @param k - the key name of the param.
+         * @param v - the value of the param
+         * @return - this.
+         */
         public Builder addQueryParam(String k, Object v) {
-            this.queryParams.put(k, v.toString());
+            if(v != null) {
+                this.queryParams.put(k, v.toString());
+            }
             return this;
         }
 
+        /**
+         * Bring all parts of our request uri together.
+         * solve our base path first, then append our query params.
+         *
+         * @param inPath - The endpoint given to the builder.
+         * @return - this.
+         */
         public Builder buildFullPath(String inPath) {
             String solvedBasePath = this.getSolvedBasePath(inPath);
             String solvedQueryParams = this.getSolvedQueryParams();
@@ -89,6 +115,15 @@ public class ServiceRequest {
             return this;
         }
 
+        /**
+         * Get the base url of our request (protocol + address + port).
+         *
+         * @param inProtocol - given protocol.
+         * @param inAddress - given address.
+         * @param inPort - given port.
+         *
+         * @return - string base path.
+         */
         private static String getBaseUrl(String inProtocol, String inAddress, String inPort) {
             StringBuilder url = new StringBuilder();
 
@@ -125,7 +160,7 @@ public class ServiceRequest {
         private String getSolvedBasePath(String inPath) {
             String rawPath = inPath;
             if(!this.pathParams.isEmpty() && rawPath.contains("{")) {
-                Matcher m = Pattern.compile("[{]+[a-zA-Z-0-9]+[}]").matcher(rawPath);
+                Matcher m = Pattern.compile(PATH_PARAM_PATTERN).matcher(rawPath);
                 while(m.find()){
                     String match = m.group();
                     String pathParamValue = this.pathParams.get(match);
@@ -137,6 +172,12 @@ public class ServiceRequest {
             return rawPath;
         }
 
+        /**
+         * Build the query param part of our request.
+         * For each query param, add ?keyname + = + value to our uri.
+         *
+         * @return - query string for uri.
+         */
         private String getSolvedQueryParams() {
             StringBuilder queryParamBuilder = new StringBuilder();
             if(!this.queryParams.isEmpty()) {
@@ -180,6 +221,9 @@ public class ServiceRequest {
         }
     }
 
+    /**
+     * Send our built request. We do not confirm results here.
+     */
     public void sendRequest() {
         AtomicReference<ClientResponse> reference = null;
         this.requestTime = System.currentTimeMillis();
@@ -267,5 +311,41 @@ public class ServiceRequest {
             totalTime = this.responseTime - this.requestTime;
         }
         return totalTime;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getPort() {
+        return port;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public HttpString getMethod() {
+        return method;
+    }
+
+    public String getRequestBody() {
+        return requestBody;
+    }
+
+    public Map<String, String> getPathParams() {
+        return pathParams;
+    }
+
+    public Map<String, String> getQueryParams() {
+        return queryParams;
+    }
+
+    public AtomicReference<ClientResponse> getResponseReference() {
+        return responseReference;
     }
 }

--- a/src/main/java/com/networknt/controller/handler/ServicesChaosMonkeyAssaultPostHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesChaosMonkeyAssaultPostHandler.java
@@ -10,6 +10,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
+import static com.networknt.controller.ControllerConstants.*;
+
 public class ServicesChaosMonkeyAssaultPostHandler implements LightHttpHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(ServicesChaosMonkeyAssaultPostHandler.class);
@@ -19,14 +21,16 @@ public class ServicesChaosMonkeyAssaultPostHandler implements LightHttpHandler {
 
         // get data from body
         Map<String, Object> body = (Map<String, Object>)exchange.getAttachment(BodyHandler.REQUEST_BODY);
-        String protocol = body.getOrDefault("protocol", "null").toString();
-        String address = body.getOrDefault("address", "null").toString();
+        String protocol = body.getOrDefault(PROTOCOL, "null").toString();
+        String address = body.getOrDefault(ADDRESS, "null").toString();
+        int port = Integer.parseInt(body.getOrDefault(PORT, "0").toString());
+
         String assaultType = body.getOrDefault("assaultType", "null").toString();
-        int port = Integer.parseInt(body.getOrDefault("port", "0").toString());
         int reqCount = Integer.parseInt(body.getOrDefault("requests", "0").toString());
         String endpointTest = body.getOrDefault("endpoint", "null").toString();
 
         String res = ControllerChaosMonkey.initChaosMonkeyAssault(assaultType, address, port, protocol, endpointTest, reqCount);
+
         exchange.getResponseHeaders().add(new HttpString("Content-Type"), "application/json");
         exchange.setStatusCode(200);
         exchange.getResponseSender().send(res);

--- a/src/main/java/com/networknt/controller/handler/ServicesChaosMonkeyAssaultPostHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesChaosMonkeyAssaultPostHandler.java
@@ -3,8 +3,9 @@ package com.networknt.controller.handler;
 import com.networknt.controller.ControllerChaosMonkey;
 import com.networknt.body.BodyHandler;
 import com.networknt.handler.LightHttpHandler;
+import com.networknt.http.MediaType;
 import io.undertow.server.HttpServerExchange;
-import io.undertow.util.HttpString;
+import io.undertow.util.Headers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,6 +16,9 @@ import static com.networknt.controller.ControllerConstants.*;
 public class ServicesChaosMonkeyAssaultPostHandler implements LightHttpHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(ServicesChaosMonkeyAssaultPostHandler.class);
+    private static final String ASSAULT_TYPE_PARAM = "assaultType";
+    private static final String REQUESTS_PARAM = "requests";
+    private static final String ENDPOINT_PARAM = "endpoint";
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
@@ -25,13 +29,13 @@ public class ServicesChaosMonkeyAssaultPostHandler implements LightHttpHandler {
         String address = body.getOrDefault(ADDRESS, "null").toString();
         int port = Integer.parseInt(body.getOrDefault(PORT, "0").toString());
 
-        String assaultType = body.getOrDefault("assaultType", "null").toString();
-        int reqCount = Integer.parseInt(body.getOrDefault("requests", "0").toString());
-        String endpointTest = body.getOrDefault("endpoint", "null").toString();
+        String assaultType = body.getOrDefault(ASSAULT_TYPE_PARAM, "null").toString();
+        int reqCount = Integer.parseInt(body.getOrDefault(REQUESTS_PARAM, "0").toString());
+        String endpointTest = body.getOrDefault(ENDPOINT_PARAM, "null").toString();
 
         String res = ControllerChaosMonkey.initChaosMonkeyAssault(assaultType, address, port, protocol, endpointTest, reqCount);
 
-        exchange.getResponseHeaders().add(new HttpString("Content-Type"), "application/json");
+        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         exchange.setStatusCode(200);
         exchange.getResponseSender().send(res);
 

--- a/src/main/java/com/networknt/controller/handler/ServicesChaosMonkeyGetHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesChaosMonkeyGetHandler.java
@@ -6,6 +6,7 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static com.networknt.controller.ControllerConstants.*;
 
 public class ServicesChaosMonkeyGetHandler implements LightHttpHandler {
 
@@ -15,9 +16,9 @@ public class ServicesChaosMonkeyGetHandler implements LightHttpHandler {
     public void handleRequest(HttpServerExchange exchange) throws Exception {
 
         // get all params
-        String protocol = exchange.getQueryParameters().get("protocol").getFirst();
-        String address = exchange.getQueryParameters().get("address").getFirst();
-        int port = Integer.parseInt(exchange.getQueryParameters().get("port").getFirst());
+        String protocol = exchange.getQueryParameters().get(PROTOCOL).getFirst();
+        String address = exchange.getQueryParameters().get(ADDRESS).getFirst();
+        int port = Integer.parseInt(exchange.getQueryParameters().get(PORT).getFirst());
 
 
 

--- a/src/main/java/com/networknt/controller/handler/ServicesChaosMonkeyGetHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesChaosMonkeyGetHandler.java
@@ -2,6 +2,7 @@ package com.networknt.controller.handler;
 
 import com.networknt.controller.ControllerChaosMonkey;
 import com.networknt.handler.LightHttpHandler;
+import com.networknt.http.MediaType;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 import org.slf4j.Logger;
@@ -20,10 +21,8 @@ public class ServicesChaosMonkeyGetHandler implements LightHttpHandler {
         String address = exchange.getQueryParameters().get(ADDRESS).getFirst();
         int port = Integer.parseInt(exchange.getQueryParameters().get(PORT).getFirst());
 
-
-
         String res = ControllerChaosMonkey.getChaosMonkeyInfo(protocol, address, port);
-        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, "application/json");
+        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         exchange.setStatusCode(200);
         exchange.getResponseSender().send(res);
     }

--- a/src/main/java/com/networknt/controller/handler/ServicesChaosMonkeyPostHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesChaosMonkeyPostHandler.java
@@ -4,6 +4,7 @@ import com.networknt.controller.ControllerChaosMonkey;
 import com.networknt.controller.model.ChaosMonkeyAssaultConfigPost;
 import com.networknt.body.BodyHandler;
 import com.networknt.handler.LightHttpHandler;
+import com.networknt.http.MediaType;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 import org.slf4j.Logger;
@@ -15,6 +16,8 @@ import static com.networknt.controller.ControllerConstants.*;
 public class ServicesChaosMonkeyPostHandler implements LightHttpHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(ServicesChaosMonkeyPostHandler.class);
+    private static final String ASSAULT_TYPE_PARAM = "assaultType";
+    private static final String ASSAULT_CONFIG_PARAM = "assaultType";
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
@@ -24,9 +27,9 @@ public class ServicesChaosMonkeyPostHandler implements LightHttpHandler {
         String address = body.getOrDefault(ADDRESS, "null").toString();
         int port = Integer.parseInt(body.getOrDefault(PORT, "null").toString());
 
-        String assaultType = body.getOrDefault("assaultType", "null").toString();
+        String assaultType = body.getOrDefault(ASSAULT_TYPE_PARAM, "null").toString();
 
-        Object config = body.getOrDefault("assaultConfig", "null");
+        Object config = body.getOrDefault(ASSAULT_CONFIG_PARAM, "null");
 
         // check if node exists
         ChaosMonkeyAssaultConfigPost<?> postBody = ControllerChaosMonkey.getChaosMonkeyAssaultConfigPostBody(assaultType, address, port, protocol, config);
@@ -34,11 +37,11 @@ public class ServicesChaosMonkeyPostHandler implements LightHttpHandler {
         // query chaos monkey handlers from service
         if(postBody != null) {
             String res = ControllerChaosMonkey.postChaosMonkeyAssault(postBody);
-            exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, "application/json");
+            exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
             exchange.setStatusCode(200);
             exchange.getResponseSender().send(res);
         } else {
-            exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, "application/json");
+            exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
             exchange.setStatusCode(404);
         }
     }

--- a/src/main/java/com/networknt/controller/handler/ServicesChaosMonkeyPostHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesChaosMonkeyPostHandler.java
@@ -8,8 +8,9 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.util.Map;
+
+import static com.networknt.controller.ControllerConstants.*;
 
 public class ServicesChaosMonkeyPostHandler implements LightHttpHandler {
 
@@ -19,10 +20,12 @@ public class ServicesChaosMonkeyPostHandler implements LightHttpHandler {
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         // get data from body
         Map<String, Object> body = (Map<String, Object>)exchange.getAttachment(BodyHandler.REQUEST_BODY);
-        String protocol = body.getOrDefault("protocol", "null").toString();
-        String address = body.getOrDefault("address", "null").toString();
+        String protocol = body.getOrDefault(PROTOCOL, "null").toString();
+        String address = body.getOrDefault(ADDRESS, "null").toString();
+        int port = Integer.parseInt(body.getOrDefault(PORT, "null").toString());
+
         String assaultType = body.getOrDefault("assaultType", "null").toString();
-        int port = Integer.parseInt(body.getOrDefault("port", "null").toString());
+
         Object config = body.getOrDefault("assaultConfig", "null");
 
         // check if node exists

--- a/src/main/java/com/networknt/controller/handler/ServicesCheckIdGetHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesCheckIdGetHandler.java
@@ -6,6 +6,7 @@ import com.networknt.client.Http2Client;
 import com.networknt.config.Config;
 import com.networknt.config.JsonMapper;
 import com.networknt.handler.LightHttpHandler;
+import com.networknt.http.MediaType;
 import com.networknt.monad.Failure;
 import com.networknt.monad.Result;
 import com.networknt.monad.Success;
@@ -19,14 +20,10 @@ import io.undertow.client.ClientRequest;
 import io.undertow.client.ClientResponse;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
-import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import org.apache.kafka.streams.KeyQueryMetadata;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.state.HostInfo;
-import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
-import org.apache.kafka.streams.state.StreamsMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnio.OptionMap;
@@ -34,7 +31,6 @@ import org.xnio.OptionMap;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -55,7 +51,7 @@ public class ServicesCheckIdGetHandler implements LightHttpHandler {
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         String id = exchange.getQueryParameters().get("id").getFirst();
         if(logger.isTraceEnabled()) logger.trace("id = " + id);
-        exchange.getResponseHeaders().add(new HttpString("Content-Type"), "application/json");
+        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         if(ControllerStartupHook.config.isClusterMode()) {
             // get from the Kafka Streams store.
             ReadOnlyKeyValueStore<String, String> healthStore = ControllerStartupHook.hcStreams.getHealthStore();

--- a/src/main/java/com/networknt/controller/handler/ServicesCheckPutHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesCheckPutHandler.java
@@ -73,6 +73,7 @@ public class ServicesCheckPutHandler implements LightHttpHandler {
 
             byte[] keyBytes = serializer.serialize(taskDefinitionKey);
             byte[] valueBytes = serializer.serialize(taskDefinition);
+
             // here we send to the health check topic directly. Not the scheduler topic.
             ProducerRecord<byte[], byte[]> tdRecord = new ProducerRecord<>(ControllerStartupHook.config.getHealthCheckTopic(), keyBytes, valueBytes);
             final CountDownLatch schedulerLatch = new CountDownLatch(1);

--- a/src/main/java/com/networknt/controller/handler/ServicesDeleteHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesDeleteHandler.java
@@ -18,6 +18,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 
+import static com.networknt.controller.ControllerConstants.*;
+
 /**
  * Remove a service from the registry with this put request. If the service doesn't exist, then no action
  * is taken. It is normally called during the service shutdown phase.
@@ -32,14 +34,14 @@ public class ServicesDeleteHandler implements LightHttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         String serviceId = exchange.getQueryParameters().get("serviceId").getFirst();
-        String protocol = exchange.getQueryParameters().get("protocol").getFirst();
+        String protocol = exchange.getQueryParameters().get(PROTOCOL).getFirst();
         String checkInterval = exchange.getQueryParameters().get("checkInterval").getFirst();
         String tag = null;
         Deque<String> tagDeque = exchange.getQueryParameters().get("tag");
         if(tagDeque != null && !tagDeque.isEmpty()) tag = tagDeque.getFirst();
         String key = tag == null ?  serviceId : serviceId + "|" + tag;
 
-        String address = exchange.getQueryParameters().get("address").getFirst();
+        String address = exchange.getQueryParameters().get(ADDRESS).getFirst();
         int port = Integer.valueOf(exchange.getQueryParameters().get("port").getFirst());
         if(logger.isDebugEnabled()) logger.debug("serviceId = " + serviceId + " protocol = " + protocol + " tag = " + tag + " address = " + address + " port = " + port);
         if(ControllerStartupHook.config.isClusterMode()) {

--- a/src/main/java/com/networknt/controller/handler/ServicesInfoNodeGetHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesInfoNodeGetHandler.java
@@ -7,6 +7,8 @@ import io.undertow.util.HttpString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.networknt.controller.ControllerConstants.*;
+
 /**
  * Query server info based on the serviceId and tag. There might be multiple instances that separated
  * by IP and Port. List all of them in an array of service info objects returned from the /server/info
@@ -20,9 +22,10 @@ public class ServicesInfoNodeGetHandler implements LightHttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         /* get server info */
-        String protocol = exchange.getQueryParameters().get("protocol").getFirst();
-        String address = exchange.getQueryParameters().get("address").getFirst();
-        int port = Integer.parseInt(exchange.getQueryParameters().get("port").getFirst());
+        String protocol = exchange.getQueryParameters().get(PROTOCOL).getFirst();
+        String address = exchange.getQueryParameters().get(ADDRESS).getFirst();
+        int port = Integer.parseInt(exchange.getQueryParameters().get(PORT).getFirst());
+
         String info = ControllerClient.getServerInfo(protocol, address, port);
 
         exchange.getResponseHeaders().add(new HttpString("Content-Type"), "application/json");

--- a/src/main/java/com/networknt/controller/handler/ServicesInfoNodeGetHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesInfoNodeGetHandler.java
@@ -2,8 +2,9 @@ package com.networknt.controller.handler;
 
 import com.networknt.controller.ControllerClient;
 import com.networknt.handler.LightHttpHandler;
+import com.networknt.http.MediaType;
 import io.undertow.server.HttpServerExchange;
-import io.undertow.util.HttpString;
+import io.undertow.util.Headers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,6 +18,7 @@ import static com.networknt.controller.ControllerConstants.*;
  * @author Steve Hu
  */
 public class ServicesInfoNodeGetHandler implements LightHttpHandler {
+
     private static final Logger logger = LoggerFactory.getLogger(ServicesDeleteHandler.class);
 
     @Override
@@ -28,7 +30,7 @@ public class ServicesInfoNodeGetHandler implements LightHttpHandler {
 
         String info = ControllerClient.getServerInfo(protocol, address, port);
 
-        exchange.getResponseHeaders().add(new HttpString("Content-Type"), "application/json");
+        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         exchange.setStatusCode(200);
         exchange.getResponseSender().send(info);
     }

--- a/src/main/java/com/networknt/controller/handler/ServicesLoggerGetContentsHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesLoggerGetContentsHandler.java
@@ -4,15 +4,22 @@ import com.networknt.controller.ControllerClient;
 import com.networknt.controller.model.LoggerInfo;
 import com.networknt.handler.LightHttpHandler;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.MediaType;
 
 import static com.networknt.controller.ControllerConstants.*;
 
 public class ServicesLoggerGetContentsHandler implements LightHttpHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(ServicesLoggerGetContentsHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ServicesLoggerGetContentsHandler.class);
+    private static final String LOGGER_NAME_PARAM = "loggerName";
+    private static final String LOGGER_LEVEL_PARAM = "loggerLevel";
+    private static final String START_TIME_PARAM = "startTime";
+    private static final String END_TIME_PARAM = "endTime";
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
@@ -20,10 +27,10 @@ public class ServicesLoggerGetContentsHandler implements LightHttpHandler {
         String address = exchange.getQueryParameters().get(ADDRESS).getFirst();
         String port = exchange.getQueryParameters().get(PORT).getFirst();
 
-        String loggerName = exchange.getQueryParameters().get("loggerName").getFirst();
-        String loggerLevel = exchange.getQueryParameters().get("loggerLevel").getFirst();
-        String startTime = exchange.getQueryParameters().get("startTime").getFirst();
-        String endTime = exchange.getQueryParameters().get("endTime").getFirst();
+        String loggerName = exchange.getQueryParameters().get(LOGGER_NAME_PARAM).getFirst();
+        String loggerLevel = exchange.getQueryParameters().get(LOGGER_LEVEL_PARAM).getFirst();
+        String startTime = exchange.getQueryParameters().get(START_TIME_PARAM).getFirst();
+        String endTime = exchange.getQueryParameters().get(END_TIME_PARAM).getFirst();
 
         LoggerInfo loggerInfo = new LoggerInfo();
         if(loggerName != null) {
@@ -33,14 +40,12 @@ public class ServicesLoggerGetContentsHandler implements LightHttpHandler {
             loggerInfo.setLevel(LoggerInfo.LevelEnum.fromValue(loggerLevel));
         }
 
-
-        if(logger.isTraceEnabled()) logger.trace("protocol = " + protocol + " address = " + address + " port = " + port);
+        if(LOG.isTraceEnabled()) LOG.trace("protocol = " + protocol + " address = " + address + " port = " + port);
 
         // use the above info to call the service to get the loggers.
         String result = ControllerClient.getLogContents(protocol, address, Integer.parseInt(port), loggerInfo, startTime, endTime);
 
-
-        exchange.getResponseHeaders().add(new HttpString("Content-Type"), "application/json");
+        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, MediaType.APPLICATION_JSON);
         exchange.setStatusCode(200);
         exchange.getResponseSender().send(result);
     }

--- a/src/main/java/com/networknt/controller/handler/ServicesLoggerGetContentsHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesLoggerGetContentsHandler.java
@@ -1,6 +1,7 @@
 package com.networknt.controller.handler;
 
 import com.networknt.controller.ControllerClient;
+import com.networknt.controller.model.LoggerInfo;
 import com.networknt.handler.LightHttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HttpString;
@@ -9,14 +10,9 @@ import org.slf4j.LoggerFactory;
 
 import static com.networknt.controller.ControllerConstants.*;
 
-/**
- * This endpoint is used to get a list of loggers with their levels for a target server instance. This is
- * the first step to update logging levels for that instance.
- *
- * @author Steve Hu
- */
-public class ServicesLoggerGetHandler implements LightHttpHandler {
-    private static final Logger logger = LoggerFactory.getLogger(ServicesLoggerGetHandler.class);
+public class ServicesLoggerGetContentsHandler implements LightHttpHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(ServicesLoggerGetContentsHandler.class);
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
@@ -24,9 +20,26 @@ public class ServicesLoggerGetHandler implements LightHttpHandler {
         String address = exchange.getQueryParameters().get(ADDRESS).getFirst();
         String port = exchange.getQueryParameters().get(PORT).getFirst();
 
+        String loggerName = exchange.getQueryParameters().get("loggerName").getFirst();
+        String loggerLevel = exchange.getQueryParameters().get("loggerLevel").getFirst();
+        String startTime = exchange.getQueryParameters().get("startTime").getFirst();
+        String endTime = exchange.getQueryParameters().get("endTime").getFirst();
+
+        LoggerInfo loggerInfo = new LoggerInfo();
+        if(loggerName != null) {
+            loggerInfo.setName(loggerName);
+        }
+        if(loggerLevel != null) {
+            loggerInfo.setLevel(LoggerInfo.LevelEnum.fromValue(loggerLevel));
+        }
+
+
         if(logger.isTraceEnabled()) logger.trace("protocol = " + protocol + " address = " + address + " port = " + port);
+
         // use the above info to call the service to get the loggers.
-        String result = ControllerClient.getLoggerConfig(protocol, address, port);
+        String result = ControllerClient.getLogContents(protocol, address, Integer.parseInt(port), loggerInfo, startTime, endTime);
+
+
         exchange.getResponseHeaders().add(new HttpString("Content-Type"), "application/json");
         exchange.setStatusCode(200);
         exchange.getResponseSender().send(result);

--- a/src/main/java/com/networknt/controller/handler/ServicesLoggerPostHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesLoggerPostHandler.java
@@ -7,10 +7,10 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HttpString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static com.networknt.controller.ControllerConstants.*;
 
 /**
  * This is the endpoint to update logging levels for a list of loggers on a target service instance.
@@ -23,9 +23,10 @@ public class ServicesLoggerPostHandler implements LightHttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         Map<String, Object> body = (Map<String, Object>)exchange.getAttachment(BodyHandler.REQUEST_BODY);
-        String protocol = (String)body.get("protocol");
-        String address = (String)body.get("address");
-        Integer port = (Integer)body.get("port");
+        String protocol = (String)body.get(PROTOCOL);
+        String address = (String)body.get(ADDRESS);
+        Integer port = (Integer)body.get(PORT);
+
         List loggers = (List)body.get("loggers");
         if(logger.isTraceEnabled()) logger.trace("protocol = " + protocol + " address = " + address + " port = " + port);
         String result = ControllerClient.updateLoggerConfig(protocol, address, port, loggers);

--- a/src/main/java/com/networknt/controller/handler/ServicesLoggerPostHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesLoggerPostHandler.java
@@ -3,8 +3,9 @@ package com.networknt.controller.handler;
 import com.networknt.controller.ControllerClient;
 import com.networknt.body.BodyHandler;
 import com.networknt.handler.LightHttpHandler;
+import com.networknt.http.MediaType;
 import io.undertow.server.HttpServerExchange;
-import io.undertow.util.HttpString;
+import io.undertow.util.Headers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.List;
@@ -18,6 +19,7 @@ import static com.networknt.controller.ControllerConstants.*;
  * @author Steve Hu
  */
 public class ServicesLoggerPostHandler implements LightHttpHandler {
+
     private static final Logger logger = LoggerFactory.getLogger(ServicesLoggerPostHandler.class);
 
     @Override
@@ -30,7 +32,7 @@ public class ServicesLoggerPostHandler implements LightHttpHandler {
         List loggers = (List)body.get("loggers");
         if(logger.isTraceEnabled()) logger.trace("protocol = " + protocol + " address = " + address + " port = " + port);
         String result = ControllerClient.updateLoggerConfig(protocol, address, port, loggers);
-        exchange.getResponseHeaders().add(new HttpString("Content-Type"), "application/json");
+        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         exchange.setStatusCode(200);
         exchange.getResponseSender().send(result);
     }

--- a/src/main/java/com/networknt/controller/handler/ServicesLookupGetHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesLookupGetHandler.java
@@ -6,6 +6,7 @@ import com.networknt.controller.ControllerStartupHook;
 import com.networknt.config.JsonMapper;
 import com.networknt.controller.ControllerUtil;
 import com.networknt.handler.LightHttpHandler;
+import com.networknt.http.MediaType;
 import com.networknt.monad.Failure;
 import com.networknt.monad.Result;
 import com.networknt.monad.Success;
@@ -33,6 +34,8 @@ import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.networknt.controller.ControllerConstants.*;
+
 /**
  * Get all healthy nodes for a registered service from the controller. This endpoint is used for
  * service discovery from the portal-registry. A serviceId query parameter is required and a tag
@@ -57,13 +60,13 @@ public class ServicesLookupGetHandler implements LightHttpHandler {
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
-        String serviceId = exchange.getQueryParameters().get("serviceId").getFirst();
+        String serviceId = exchange.getQueryParameters().get(SERVICE_ID).getFirst();
         String tag = null;
-        Deque<String> tagDeque = exchange.getQueryParameters().get("tag");
+        Deque<String> tagDeque = exchange.getQueryParameters().get(TAG);
         if(tagDeque != null && !tagDeque.isEmpty()) tag = tagDeque.getFirst();
         String key = tag == null ? serviceId : serviceId + "|" + tag;
         if(logger.isDebugEnabled()) logger.debug("key = " + key  + " serviceId = " + serviceId + " tag = " + tag);
-        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, "application/json");
+        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
        if(ControllerStartupHook.config.isClusterMode()) {
            // get the stale health checks and potentially filter out the un-healthy services in the result.
            if(checks == null || System.currentTimeMillis() - lastLoadChecks > checkCachePeriod) {

--- a/src/main/java/com/networknt/controller/handler/ServicesPostHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesPostHandler.java
@@ -35,8 +35,8 @@ public class ServicesPostHandler implements LightHttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         Map<String, Object> body = (Map<String, Object>)exchange.getAttachment(BodyHandler.REQUEST_BODY);
-        String serviceId = (String)body.get("serviceId");
-        String tag = (String)body.get("tag");
+        String serviceId = (String)body.get(SERVICE_ID);
+        String tag = (String)body.get(TAG);
         String key = tag == null ? serviceId : serviceId + "|" + tag;
         String protocol = (String)body.get(PROTOCOL);
         String address = (String)body.get(ADDRESS);
@@ -99,9 +99,9 @@ public class ServicesPostHandler implements LightHttpHandler {
             dataMap.put("executeInterval", String.valueOf(check.getExecuteInterval()));
             dataMap.put("lastExecuteTimestamp", String.valueOf(check.getLastExecuteTimestamp()));
             dataMap.put("lastFailedTimestamp", String.valueOf(check.getLastFailedTimestamp()));
-            dataMap.put("serviceId", check.getServiceId());
-            dataMap.put("tag", check.getTag());
 
+            dataMap.put(SERVICE_ID, check.getServiceId());
+            dataMap.put(TAG, check.getTag());
             dataMap.put(PROTOCOL, check.getProtocol());
             dataMap.put(ADDRESS, check.getAddress());
             dataMap.put(PORT, String.valueOf(check.getPort()));

--- a/src/main/java/com/networknt/controller/handler/ServicesPostHandler.java
+++ b/src/main/java/com/networknt/controller/handler/ServicesPostHandler.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import static com.networknt.controller.ControllerConstants.*;
 
 /**
  * Register a service to the controller to indicate it is alive. It is normally called
@@ -37,9 +38,10 @@ public class ServicesPostHandler implements LightHttpHandler {
         String serviceId = (String)body.get("serviceId");
         String tag = (String)body.get("tag");
         String key = tag == null ? serviceId : serviceId + "|" + tag;
-        String protocol = (String)body.get("protocol");
-        String address = (String)body.get("address");
-        int port = (Integer)body.get("port");
+        String protocol = (String)body.get(PROTOCOL);
+        String address = (String)body.get(ADDRESS);
+        int port = (Integer)body.get(PORT);
+
         Check check = JsonMapper.objectMapper.convertValue(body.get(ControllerConstants.CHECK), Check.class);
         if(logger.isDebugEnabled()) logger.debug("serviceId = " + serviceId + " tag = " + tag + " protocol = " + protocol + " address = " + address + " port = " + port + " check = " + body.get(ControllerConstants.CHECK));
         if(ControllerStartupHook.config.isClusterMode()) {
@@ -99,9 +101,10 @@ public class ServicesPostHandler implements LightHttpHandler {
             dataMap.put("lastFailedTimestamp", String.valueOf(check.getLastFailedTimestamp()));
             dataMap.put("serviceId", check.getServiceId());
             dataMap.put("tag", check.getTag());
-            dataMap.put("protocol", check.getProtocol());
-            dataMap.put("address", check.getAddress());
-            dataMap.put("port", String.valueOf(check.getPort()));
+
+            dataMap.put(PROTOCOL, check.getProtocol());
+            dataMap.put(ADDRESS, check.getAddress());
+            dataMap.put(PORT, String.valueOf(check.getPort()));
 
             TaskDefinition taskDefinition = TaskDefinition.newBuilder()
                     .setName(check.getId())
@@ -131,9 +134,9 @@ public class ServicesPostHandler implements LightHttpHandler {
 
         } else {
             Map<String, Object> nodeMap = new ConcurrentHashMap<>();
-            nodeMap.put("protocol", protocol);
-            nodeMap.put("address", address);
-            nodeMap.put("port", port);
+            nodeMap.put(PROTOCOL, protocol);
+            nodeMap.put(ADDRESS, address);
+            nodeMap.put(PORT, port);
 
             List nodes = (List) ControllerStartupHook.services.get(key);
             nodes = addService(nodes, nodeMap);
@@ -153,12 +156,12 @@ public class ServicesPostHandler implements LightHttpHandler {
             nodes.add(nodeMap);
         } else {
             // delete the nodeMap if it is already there before adding it.
-            String address = (String)nodeMap.get("address");
-            int port = (Integer)nodeMap.get("port");
+            String address = (String)nodeMap.get(ADDRESS);
+            int port = (Integer)nodeMap.get(PORT);
             for(Iterator<Map<String, Object>> iter = nodes.iterator(); iter.hasNext(); ) {
                 Map<String, Object> map = iter.next();
-                String a = (String)map.get("address");
-                int p = (Integer)map.get("port");
+                String a = (String)map.get(ADDRESS);
+                int p = (Integer)map.get(PORT);
                 if (address.equals(a) && port == p)
                     iter.remove();
             }

--- a/src/main/resources/config/handler.yml
+++ b/src/main/resources/config/handler.yml
@@ -83,6 +83,7 @@ handlers:
   - com.networknt.controller.handler.WebSocketHandler
   - com.networknt.controller.handler.ServicesLoggerGetHandler
   - com.networknt.controller.handler.ServicesLoggerPostHandler
+  - com.networknt.controller.handler.ServicesLoggerGetContentsHandler
   - com.networknt.controller.handler.ServicesChaosMonkeyGetHandler
   - com.networknt.controller.handler.ServicesChaosMonkeyPostHandler
   - com.networknt.controller.handler.ServicesChaosMonkeyAssaultPostHandler
@@ -180,6 +181,11 @@ paths:
     exec:
       - basic
       - com.networknt.controller.handler.ServicesLoggerGetHandler
+  - path: '/services/logger/contents'
+    method: 'GET'
+    exec:
+      - basic
+      - com.networknt.controller.handler.ServicesLoggerGetContentsHandler
   - path: '/services/logger'
     method: 'POST'
     exec:


### PR DESCRIPTION
### Added new '/services/logger/contents' endpoint.
*  takes params:
    - **port**: port of the service.
    - **address**: address of the service.
    - **protocol**: protocol of the service.
    - **loggerName**: log name you want to get contents from.
    - **loggerLevel**: level of the log you want to get from (ie. DEBUG, INFO, etc).
    - **startTime**: the start range for log entries you want to grab.
    - endTime: the end range for log entries you want to grab.
* returns a JSON body of log entries from a service registered.
        
### Added log confirmation to chaos monkey  
* returns log contents  after chaos monkey assault is executed
* if kill app or exception assault is used, wait for a default timeout of 30000ms (30 seconds) to see logs when the service comes back up.